### PR TITLE
Type safe props

### DIFF
--- a/src/main/scala/de/bripkens/ha/App.scala
+++ b/src/main/scala/de/bripkens/ha/App.scala
@@ -32,7 +32,7 @@ object App extends scala.App {
     implicit val system = ActorSystem("ha")
 
     // the AppActor gets us started from here on out
-    system.actorOf(Props(classOf[AppActor], mapper, configuration), "app")
+    system.actorOf(AppActor.props(mapper, configuration), AppActor.Name)
   }
 
   def reportCriticalInitialisationError(msg: String): Unit = {

--- a/src/main/scala/de/bripkens/ha/AppActor.scala
+++ b/src/main/scala/de/bripkens/ha/AppActor.scala
@@ -3,6 +3,13 @@ package de.bripkens.ha
 import akka.actor.{Props, ActorLogging, Actor}
 import com.fasterxml.jackson.databind.ObjectMapper
 
+object AppActor {
+
+  final val Name = "app"
+
+  def props(mapper: ObjectMapper, config: Configuration) = Props(new AppActor(mapper, config))
+}
+
 class AppActor(val mapper: ObjectMapper, val config: Configuration) extends Actor
                                                                     with ActorLogging {
 

--- a/src/main/scala/de/bripkens/ha/AppActor.scala
+++ b/src/main/scala/de/bripkens/ha/AppActor.scala
@@ -14,10 +14,10 @@ object AppActor {
 class AppActor(val mapper: ObjectMapper, val config: Configuration) extends Actor
                                                                     with ActorLogging {
 
-  val reporters = config.reporters.map{ case (name, reporterConfig) => 
+  val reporters = config.reporters.map{ case (name, reporterConfig) =>
     val props = reporterConfig match {
-      case config@ConsoleReporterConfig(_)           => ConsoleReporter.props(mapper, config)
-      case config@SlackReporterConfig(_, _, _, _, _) => SlackReporter.props(mapper, config)
+      case config: ConsoleReporterConfig => ConsoleReporter.props(mapper, config)
+      case config: SlackReporterConfig   => SlackReporter.props(mapper, config)
     }
 
     val actor = context.actorOf(props, s"reporter-$name")

--- a/src/main/scala/de/bripkens/ha/AppActor.scala
+++ b/src/main/scala/de/bripkens/ha/AppActor.scala
@@ -28,7 +28,7 @@ class AppActor(val mapper: ObjectMapper, val config: Configuration) extends Acto
     }
     val reporter = reporters(endpoint.reporter)
     context.actorOf(
-      Props(classOf[HealthCheckActor], mapper, config, endpoint, reporter),
+      HealthCheckActor.props(mapper, config, endpoint, reporter),
       s"healthCheck-${endpoint.id}"
     )
   }

--- a/src/main/scala/de/bripkens/ha/AppActor.scala
+++ b/src/main/scala/de/bripkens/ha/AppActor.scala
@@ -18,8 +18,8 @@ class AppActor(val mapper: ObjectMapper, val config: Configuration) extends Acto
 
   def config2Actor(entry: (String, AbstractReporterConfig)): (String, ActorRef) = {
     val props = entry._2 match {
-      case crc@ConsoleReporterConfig(_)           => Props(new ConsoleReporter(mapper, crc))
-      case src@SlackReporterConfig(_, _, _, _, _) => Props(new SlackReporter(mapper, src))
+      case config@ConsoleReporterConfig(_)           => ConsoleReporter.props(mapper, config)
+      case config@SlackReporterConfig(_, _, _, _, _) => SlackReporter.props(mapper, config)
     }
 
     val actor = context.actorOf(props, s"reporter-${entry._1}")

--- a/src/main/scala/de/bripkens/ha/AppActor.scala
+++ b/src/main/scala/de/bripkens/ha/AppActor.scala
@@ -16,7 +16,7 @@ class AppActor(val mapper: ObjectMapper, val config: Configuration) extends Acto
 
   val reporters = config.reporters.map(config2Actor)
 
-  def config2Actor(entry: (String, AbstractReporterConfig)): (String, ActorRef) = {
+  def config2Actor(entry: (String, ReporterConfig)): (String, ActorRef) = {
     val props = entry._2 match {
       case config@ConsoleReporterConfig(_)           => ConsoleReporter.props(mapper, config)
       case config@SlackReporterConfig(_, _, _, _, _) => SlackReporter.props(mapper, config)

--- a/src/main/scala/de/bripkens/ha/Configuration.scala
+++ b/src/main/scala/de/bripkens/ha/Configuration.scala
@@ -24,7 +24,7 @@ object Configuration {
 
 @JsonCreator
 case class Configuration(@JsonProperty("endpoints") endpoints: Set[HealthCheckEndpoint],
-                         @JsonProperty("reporters") reporters: Map[String, AbstractReporterConfig],
+                         @JsonProperty("reporters") reporters: Map[String, ReporterConfig],
                          @JsonProperty("akka") akkaConfig: Map[String, _ <: AnyRef])
 
 @JsonCreator
@@ -44,14 +44,14 @@ case class HealthCheckEndpoint(@JsonProperty("url") url: String,
   new JsonSubTypes.Type(value = classOf[SlackReporterConfig], name = "slack"),
   new JsonSubTypes.Type(value = classOf[ConsoleReporterConfig], name = "console")
 ))
-abstract class AbstractReporterConfig(@JsonProperty("type") reporterType: String)
+sealed trait ReporterConfig
 
 case class SlackReporterConfig(@JsonProperty("type") reporterType: String,
                                @JsonProperty("channel") channel: String,
                                @JsonProperty("webhookUrl") webhookUrl: String,
                                @JsonProperty("botName") botName: String,
                                @JsonProperty("botImage") botImage: String)
-  extends AbstractReporterConfig(reporterType)
+  extends ReporterConfig
 
 case class ConsoleReporterConfig(@JsonProperty("type") reporterType: String)
-  extends AbstractReporterConfig(reporterType)
+  extends ReporterConfig

--- a/src/main/scala/de/bripkens/ha/Configuration.scala
+++ b/src/main/scala/de/bripkens/ha/Configuration.scala
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.annotation.{JsonCreator, JsonProperty, JsonSubTypes
 import com.fasterxml.jackson.databind.{JsonMappingException, ObjectMapper}
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
-import de.bripkens.ha.reporting.{ConsoleReporter, SlackReporter}
 
 import scala.util.control.Exception._
 
@@ -45,20 +44,14 @@ case class HealthCheckEndpoint(@JsonProperty("url") url: String,
   new JsonSubTypes.Type(value = classOf[SlackReporterConfig], name = "slack"),
   new JsonSubTypes.Type(value = classOf[ConsoleReporterConfig], name = "console")
 ))
-abstract class AbstractReporterConfig(@JsonProperty("type") reporterType: String) {
-  val implementation: Class[_]
-}
+abstract class AbstractReporterConfig(@JsonProperty("type") reporterType: String)
 
 case class SlackReporterConfig(@JsonProperty("type") reporterType: String,
                                @JsonProperty("channel") channel: String,
                                @JsonProperty("webhookUrl") webhookUrl: String,
                                @JsonProperty("botName") botName: String,
                                @JsonProperty("botImage") botImage: String)
-  extends AbstractReporterConfig(reporterType) {
-  override val implementation = classOf[SlackReporter]
-}
+  extends AbstractReporterConfig(reporterType)
 
 case class ConsoleReporterConfig(@JsonProperty("type") reporterType: String)
-  extends AbstractReporterConfig(reporterType) {
-  override val implementation = classOf[ConsoleReporter]
-}
+  extends AbstractReporterConfig(reporterType)

--- a/src/main/scala/de/bripkens/ha/HealthCheckActor.scala
+++ b/src/main/scala/de/bripkens/ha/HealthCheckActor.scala
@@ -2,16 +2,25 @@ package de.bripkens.ha
 
 import java.util.concurrent.TimeUnit
 
-import akka.pattern.after
 import akka.actor.Status.Failure
-import akka.actor.{ActorRef, ActorLogging, Actor}
+import akka.actor.{Props, Actor, ActorLogging, ActorRef}
 import akka.http.scaladsl.Http
-import akka.http.scaladsl.model.{StatusCodes, HttpResponse, HttpRequest}
+import akka.http.scaladsl.model.{HttpRequest, HttpResponse, StatusCodes}
+import akka.pattern.after
 import akka.stream.scaladsl.ImplicitMaterializer
 import com.fasterxml.jackson.databind.ObjectMapper
 
-import scala.concurrent.{TimeoutException, Future}
 import scala.concurrent.duration._
+import scala.concurrent.{Future, TimeoutException}
+
+object HealthCheckActor {
+
+  def props(mapper: ObjectMapper,
+            config: Configuration,
+            endpoint: HealthCheckEndpoint,
+            reporter: ActorRef) = Props(new HealthCheckActor(mapper, config, endpoint, reporter))
+
+}
 
 class HealthCheckActor(val mapper: ObjectMapper,
                        val config: Configuration,

--- a/src/main/scala/de/bripkens/ha/HealthCheckActor.scala
+++ b/src/main/scala/de/bripkens/ha/HealthCheckActor.scala
@@ -19,7 +19,6 @@ object HealthCheckActor {
             config: Configuration,
             endpoint: HealthCheckEndpoint,
             reporter: ActorRef) = Props(new HealthCheckActor(mapper, config, endpoint, reporter))
-
 }
 
 class HealthCheckActor(val mapper: ObjectMapper,

--- a/src/main/scala/de/bripkens/ha/reporting/ConsoleReporter.scala
+++ b/src/main/scala/de/bripkens/ha/reporting/ConsoleReporter.scala
@@ -1,11 +1,17 @@
 package de.bripkens.ha.reporting
 
-import akka.actor.{ActorLogging, Actor}
+import akka.actor.{Props, ActorLogging, Actor}
 import com.fasterxml.jackson.databind.ObjectMapper
 import de.bripkens.ha.ComponentStatus.ComponentStatus
 import de.bripkens.ha.{ComponentStatus, ComponentStatusUpdate, ConsoleReporterConfig}
 
 import scala.collection.mutable
+
+object ConsoleReporter {
+
+  def props(mapper: ObjectMapper, config: ConsoleReporterConfig) = Props(new ConsoleReporter(mapper, config))
+
+}
 
 class ConsoleReporter(val mapper: ObjectMapper, val config: ConsoleReporterConfig) extends Actor
                                                                                    with ActorLogging {

--- a/src/main/scala/de/bripkens/ha/reporting/SlackReporter.scala
+++ b/src/main/scala/de/bripkens/ha/reporting/SlackReporter.scala
@@ -1,6 +1,6 @@
 package de.bripkens.ha.reporting
 
-import akka.actor.{ActorLogging, Actor}
+import akka.actor.{Props, ActorLogging, Actor}
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
 import akka.stream.scaladsl.ImplicitMaterializer
@@ -9,6 +9,12 @@ import de.bripkens.ha.ComponentStatus._
 import de.bripkens.ha.{HealthCheckEndpoint, ComponentStatus, ComponentStatusUpdate, SlackReporterConfig}
 
 import scala.collection.mutable
+
+object SlackReporter {
+
+  def props(mapper: ObjectMapper, config: SlackReporterConfig) = Props(new SlackReporter(mapper, config))
+
+}
 
 class SlackReporter(val mapper: ObjectMapper, val config: SlackReporterConfig) extends Actor
                                                                                with ActorLogging


### PR DESCRIPTION
Apply akka best practices: Introduce props methods in the companion objects of Actors for creating Props in a type safe manner.
