### PR TITLE
Remove explicit script definition from .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ scala:
   - 2.11.2
 jdk:
   - oraclejdk8
-script: sbt package


### PR DESCRIPTION
The default for scala builds at Travis CIS is sbt test. sbt package
does not seem to run tests. Remove explicit script definition. This
also fixes #7.
