### PR TITLE
Unhandled messages

### DIFF
--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,1 @@
+akka.actor.debug.unhandled = true

--- a/src/main/scala/de/bripkens/ha/AppActor.scala
+++ b/src/main/scala/de/bripkens/ha/AppActor.scala
@@ -36,7 +36,6 @@ class AppActor(val mapper: ObjectMapper, val config: Configuration) extends Acto
     )
   }
 
-  override def receive: Receive = {
-    case unsupported => log.error(s"Unsupported message received: $unsupported")
-  }
+  override def receive = Actor.emptyBehavior
+
 }

--- a/src/main/scala/de/bripkens/ha/HealthCheckActor.scala
+++ b/src/main/scala/de/bripkens/ha/HealthCheckActor.scala
@@ -63,6 +63,5 @@ class HealthCheckActor(val mapper: ObjectMapper,
     case failure: Failure => {
       reporter ! ComponentStatusUpdate(endpoint, ComponentStatus.NOT_REACHABLE)
     }
-    case unsupported => log.error(s"Unsupported message received: $unsupported")
   }
 }

--- a/src/main/scala/de/bripkens/ha/reporting/ConsoleReporter.scala
+++ b/src/main/scala/de/bripkens/ha/reporting/ConsoleReporter.scala
@@ -37,7 +37,6 @@ class ConsoleReporter(val mapper: ObjectMapper, val config: ConsoleReporterConfi
         componentStatus.put(component.id, ComponentStatus.NOT_REACHABLE)
       }
     }
-    case unsupported => log.error(s"Unsupported message received: $unsupported")
   }
 
 }

--- a/src/main/scala/de/bripkens/ha/reporting/SlackReporter.scala
+++ b/src/main/scala/de/bripkens/ha/reporting/SlackReporter.scala
@@ -45,7 +45,6 @@ class SlackReporter(val mapper: ObjectMapper, val config: SlackReporterConfig) e
         log.warning(s"Retrieved status code ${response.status} from the Slack API")
       }
     }
-    case unsupported => log.error(s"Unsupported message received: $unsupported")
   }
 
   def onStatusChange(component: HealthCheckEndpoint,

--- a/src/test/scala/de/bripkens/ha/reporting/ConsoleReporterSpec.scala
+++ b/src/test/scala/de/bripkens/ha/reporting/ConsoleReporterSpec.scala
@@ -30,5 +30,13 @@ class ConsoleReporterSpec extends BaseAkkaSpec {
       }
 
     }
+
+    "log a warning when it receives an unknown message" in {
+      val reporter = system.actorOf(Props(new ConsoleReporter(new ObjectMapper, new ConsoleReporterConfig(""))))
+
+      EventFilter.warning(occurrences = 1).intercept {
+        reporter ! "unknown message"
+      }
+    }
   }
 }


### PR DESCRIPTION
Akka's default behavior for unhandled messages is to send a `akka.actor.UnhandledMessage` to the actor system's global event stream. By handling even the unknown messages in our actor implementations, we're breaking this fall back.

This PR changes the implemenation of all receive methods to ignore unknown messages so that they can be handled by the actor system instead.
