### PR TITLE
Use Try instead of Either

### DIFF
--- a/src/main/scala/de/bripkens/ha/App.scala
+++ b/src/main/scala/de/bripkens/ha/App.scala
@@ -1,9 +1,11 @@
 package de.bripkens.ha
 
-import java.nio.file.{Paths, NoSuchFileException}
+import java.nio.file.{NoSuchFileException, Paths}
 
-import akka.actor.{ActorSystem, Props}
+import akka.actor.ActorSystem
 import com.fasterxml.jackson.databind.JsonMappingException
+
+import scala.util.{Failure, Success}
 
 object App extends scala.App {
 
@@ -17,13 +19,13 @@ object App extends scala.App {
   Console.out.println(s"Starting with config file $configPath")
 
   Configuration.load(Paths.get(configPath)) match {
-    case Left(e: NoSuchFileException) => reportCriticalInitialisationError(
+    case Success(configuration) => startActorSystem(configuration)
+    case Failure(e: NoSuchFileException) => reportCriticalInitialisationError(
       s"Config file $configPath does not exist."
     )
-    case Left(e: JsonMappingException) => reportCriticalInitialisationError(
+    case Failure(e: JsonMappingException) => reportCriticalInitialisationError(
       s"Config file $configPath could not be parsed. Error: ${e.getMessage}"
     )
-    case Right(configuration) => startActorSystem(configuration)
   }
 
   def startActorSystem(configuration: Configuration) = {

--- a/src/main/scala/de/bripkens/ha/Configuration.scala
+++ b/src/main/scala/de/bripkens/ha/Configuration.scala
@@ -1,24 +1,24 @@
 package de.bripkens.ha
 
-import java.nio.file.{Files, NoSuchFileException, Path}
+import java.nio.file.{Files, Path}
 
-import com.fasterxml.jackson.annotation.{JsonCreator, JsonProperty, JsonSubTypes, JsonTypeInfo}
-import com.fasterxml.jackson.databind.{JsonMappingException, ObjectMapper}
+import com.fasterxml.jackson.annotation.{JsonProperty, JsonSubTypes, JsonTypeInfo}
+import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 
-import scala.util.control.Exception._
+import scala.util.Try
 
 object Configuration {
 
-  def load(path: Path): Either[Throwable, Configuration] = {
+  def load(path: Path): Try[Configuration] = {
     val yamlMapper = new ObjectMapper(new YAMLFactory())
     yamlMapper.registerModule(DefaultScalaModule)
 
-    catching(classOf[NoSuchFileException], classOf[JsonMappingException]) either {
+    Try({
       val content = String.join("\n", Files.readAllLines(path))
       yamlMapper.readValue(content, classOf[Configuration])
-    }
+    })
   }
 }
 

--- a/src/test/scala/de/bripkens/ha/ConfigurationSpec.scala
+++ b/src/test/scala/de/bripkens/ha/ConfigurationSpec.scala
@@ -3,9 +3,9 @@ package de.bripkens.ha
 import java.nio.file.{NoSuchFileException, Paths}
 
 import com.fasterxml.jackson.databind.JsonMappingException
-import org.scalatest.{EitherValues, Matchers, WordSpec}
+import org.scalatest.{Matchers, WordSpec, TryValues}
 
-class ConfigurationSpec extends WordSpec with Matchers with EitherValues {
+class ConfigurationSpec extends WordSpec with Matchers with TryValues {
 
   "Configuration" when {
 
@@ -13,8 +13,8 @@ class ConfigurationSpec extends WordSpec with Matchers with EitherValues {
 
       val path = Paths.get(getClass.getResource("test-config.yml").toURI)
       val loaded = Configuration.load(path)
-      loaded should be('right)
-      val configuration = loaded.right.get
+      loaded should be a 'success
+      val configuration = loaded.success.value
 
       "have two endpoints" in {
         configuration.endpoints should have size 2
@@ -53,8 +53,8 @@ class ConfigurationSpec extends WordSpec with Matchers with EitherValues {
         val path = Paths.get("/does/not/exist")
 
         val loaded = Configuration.load(path)
-        loaded should be('left)
-        loaded.left.value shouldBe a[NoSuchFileException]
+        loaded should be a 'failure
+        loaded.failure.exception shouldBe a[NoSuchFileException]
       }
     }
 
@@ -64,8 +64,8 @@ class ConfigurationSpec extends WordSpec with Matchers with EitherValues {
         val path = Paths.get(getClass.getResource("broken-config.yml").toURI)
 
         val loaded = Configuration.load(path)
-        loaded should be('left)
-        loaded.left.value shouldBe a[JsonMappingException]
+        loaded should be a 'failure
+        loaded.failure.exception shouldBe a[JsonMappingException]
       }
     }
   }


### PR DESCRIPTION
`Either` has two main problems:
1. Using `Right` for the good case is just a convention and not encoded in the type system
2. it is not monadic

It's better to use Try for modeling operations that may fail. Replace `Either` in in `Configuration` with `Try`.
