### PR TITLE
Implement main method explicitly instead of using the scala.App trait

### DIFF
--- a/src/main/scala/de/bripkens/ha/App.scala
+++ b/src/main/scala/de/bripkens/ha/App.scala
@@ -7,28 +7,30 @@ import com.fasterxml.jackson.databind.JsonMappingException
 
 import scala.util.{Failure, Success}
 
-object App extends scala.App {
+object App {
 
-  if (args.length != 1) {
-    reportCriticalInitialisationError(
-      "Please specify exactly one parameter: The path to the config file."
-    )
+  def main(args: Array[String]) {
+    if (args.length != 1) {
+      reportCriticalInitialisationError(
+        "Please specify exactly one parameter: The path to the config file."
+      )
+    }
+
+    val configPath = args(0)
+    Console.out.println(s"Starting with config file $configPath")
+
+    Configuration.load(Paths.get(configPath)) match {
+      case Success(configuration) => startActorSystem(configuration)
+      case Failure(e: NoSuchFileException) => reportCriticalInitialisationError(
+        s"Config file $configPath does not exist."
+      )
+      case Failure(e: JsonMappingException) => reportCriticalInitialisationError(
+        s"Config file $configPath could not be parsed. Error: ${e.getMessage}"
+      )
+    }
   }
 
-  val configPath = args(0)
-  Console.out.println(s"Starting with config file $configPath")
-
-  Configuration.load(Paths.get(configPath)) match {
-    case Success(configuration) => startActorSystem(configuration)
-    case Failure(e: NoSuchFileException) => reportCriticalInitialisationError(
-      s"Config file $configPath does not exist."
-    )
-    case Failure(e: JsonMappingException) => reportCriticalInitialisationError(
-      s"Config file $configPath could not be parsed. Error: ${e.getMessage}"
-    )
-  }
-
-  def startActorSystem(configuration: Configuration) = {
+  private def startActorSystem(configuration: Configuration) = {
     Console.out.println("Config successfully loaded. Initializing actor system.")
 
     implicit val system = ActorSystem("ha")
@@ -37,7 +39,7 @@ object App extends scala.App {
     system.actorOf(AppActor.props(mapper, configuration), AppActor.Name)
   }
 
-  def reportCriticalInitialisationError(msg: String): Unit = {
+  private def reportCriticalInitialisationError(msg: String): Unit = {
     Console.err.println(msg)
     System.exit(1)
   }


### PR DESCRIPTION
I've learned from @hseeberger, that the `App` trait has some nasty details to be aware off. It uses `DelayedInit` which is deprecated and will be removed in the future. One problem is the initialization order, which can cause problems.

For this reason it's better to simply implement a `main` method explicitly get rid of the `App` trait.
