### PR TITLE
Update to Akka 2.4.7

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,8 +4,7 @@ object Version {
   final val Scala                 = "2.11.8"
   final val ScalaTest             = "3.0.0-RC2"
   final val JacksonVersion        = "2.6.3"
-  final val AkkaVersion           = "2.4.2"
-  final val AkkaExtensionsVersion = "2.0.3"
+  final val AkkaVersion           = "2.4.7"
 }
 
 object Library {
@@ -18,13 +17,13 @@ object Library {
   }
 
   object Akka {
-    val actor    = "com.typesafe.akka" %% "akka-actor"                  % Version.AkkaVersion
-    val contrib  = "com.typesafe.akka" %% "akka-contrib"                % Version.AkkaVersion
-    val testkit  = "com.typesafe.akka" %% "akka-testkit"                % Version.AkkaVersion
+    val actor    = "com.typesafe.akka" %% "akka-actor"              % Version.AkkaVersion
+    val contrib  = "com.typesafe.akka" %% "akka-contrib"            % Version.AkkaVersion
+    val testkit  = "com.typesafe.akka" %% "akka-testkit"            % Version.AkkaVersion
 
-    val stream   = "com.typesafe.akka" %% "akka-stream-experimental"    % Version.AkkaExtensionsVersion
-    val httpCore = "com.typesafe.akka" %% "akka-http-core-experimental" % Version.AkkaExtensionsVersion
-    val http     = "com.typesafe.akka" %% "akka-http-experimental"      % Version.AkkaExtensionsVersion
+    val stream   = "com.typesafe.akka" %% "akka-stream"             % Version.AkkaVersion
+    val httpCore = "com.typesafe.akka" %% "akka-http-core"          % Version.AkkaVersion
+    val http     = "com.typesafe.akka" %% "akka-http-experimental"  % Version.AkkaVersion
   }
 
   val scalaTest = "org.scalatest" %% "scalatest" % Version.ScalaTest

--- a/src/main/scala/de/bripkens/ha/HealthCheckActor.scala
+++ b/src/main/scala/de/bripkens/ha/HealthCheckActor.scala
@@ -19,11 +19,11 @@ package de.bripkens.ha
 import java.util.concurrent.TimeUnit
 
 import akka.actor.Status.Failure
-import akka.actor.{ Props, Actor, ActorLogging, ActorRef }
+import akka.actor.{ Actor, ActorLogging, ActorRef, Props }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model.{ HttpRequest, HttpResponse, StatusCodes }
 import akka.pattern.after
-import akka.stream.scaladsl.ImplicitMaterializer
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
 import com.fasterxml.jackson.databind.ObjectMapper
 
 import scala.concurrent.duration._
@@ -45,14 +45,15 @@ class HealthCheckActor(
   val endpoint: HealthCheckEndpoint,
   val reporter: ActorRef
 ) extends Actor
-    with ActorLogging
-    with ImplicitMaterializer {
+    with ActorLogging {
 
   import context.dispatcher
 
   // make the pipeTo method available (requires the ExecutionContextExecutor)
   // on Future
   import akka.pattern.pipe
+
+  final implicit val materializer: ActorMaterializer = ActorMaterializer(ActorMaterializerSettings(context.system))
 
   private val http = Http(context.system)
 

--- a/src/main/scala/de/bripkens/ha/reporting/SlackReporter.scala
+++ b/src/main/scala/de/bripkens/ha/reporting/SlackReporter.scala
@@ -16,13 +16,13 @@
 
 package de.bripkens.ha.reporting
 
-import akka.actor.{ Props, ActorLogging, Actor }
+import akka.actor.{ Actor, ActorLogging, Props }
 import akka.http.scaladsl.Http
 import akka.http.scaladsl.model._
-import akka.stream.scaladsl.ImplicitMaterializer
+import akka.stream.{ ActorMaterializer, ActorMaterializerSettings }
 import com.fasterxml.jackson.databind.ObjectMapper
 import de.bripkens.ha.ComponentStatus._
-import de.bripkens.ha.{ HealthCheckEndpoint, ComponentStatus, ComponentStatusUpdate, SlackReporterConfig }
+import de.bripkens.ha.{ ComponentStatus, ComponentStatusUpdate, HealthCheckEndpoint, SlackReporterConfig }
 
 import scala.collection.mutable
 
@@ -33,14 +33,15 @@ object SlackReporter {
 }
 
 class SlackReporter(val mapper: ObjectMapper, val config: SlackReporterConfig) extends Actor
-    with ActorLogging
-    with ImplicitMaterializer {
+    with ActorLogging {
 
   import context.dispatcher
 
   // make the pipeTo method available (requires the ExecutionContextExecutor)
   // on Future
   import akka.pattern.pipe
+
+  final implicit val materializer: ActorMaterializer = ActorMaterializer(ActorMaterializerSettings(context.system))
 
   val componentStatus = new mutable.HashMap[String, ComponentStatus]()
 


### PR DESCRIPTION
This will allow us to drop the Akka extensions version number, since now Akka core and Akka Stream have the same version. Further more the eviction warning during the build will go away.

Note that I had to change the way we pass the ActorMaterializer, since the ImplcitActorMaterializer trait has been dropped in Akka stream 2.4.x (see http://doc.akka.io/docs/akka/2.4.2/scala/stream/migration-guide-2.0-2.4-scala.html)
