### PR TITLE
Drop unused akkaConfig property from Configuration

### DIFF
--- a/src/main/scala/de/bripkens/ha/Configuration.scala
+++ b/src/main/scala/de/bripkens/ha/Configuration.scala
@@ -40,8 +40,7 @@ object Configuration {
 
 case class Configuration(
   @JsonProperty("endpoints") endpoints: Set[HealthCheckEndpoint],
-  @JsonProperty("reporters") reporters: Map[String, ReporterConfig],
-  @JsonProperty("akka") akkaConfig: Map[String, _ <: AnyRef]
+  @JsonProperty("reporters") reporters: Map[String, ReporterConfig]
 )
 
 case class HealthCheckEndpoint(


### PR DESCRIPTION
The property is not used and blocks me from reimplementing configuration parsing with circe. There are [better/more idomatic ways to pass the akka configuration from outside](http://doc.akka.io/docs/akka/snapshot/general/configuration.html) and we should probably do it like that if we really need to apply custom configuration.
